### PR TITLE
METAR

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,5 +48,6 @@ The output will look like this:
       , dewPoint = Just 15
       , trend = NOSIG
       , remark = Nothing
+      , maintenance = False
           }
     ...

--- a/avwx.cabal
+++ b/avwx.cabal
@@ -17,12 +17,16 @@ library
   hs-source-dirs:      src
   exposed-modules:     Data.Aviation.WX
                      , Data.Aviation.WX.Fetcher
-  -- other-modules:       Data.Aviation.WX.Fetcher
+  
   build-depends:       base >= 4.7 && < 5
-                     , attoparsec
-                     , HTTP
-                     , text
+                     , lens >= 4.1 && < 5
+                     , attoparsec >= 0.13 && < 1
+                     , parsers >= 0.12 && < 1
+                     , HTTP >= 4000 && < 5000
+                     , text >= 1.2.2.1 && < 1.3
+                     
   default-language:    Haskell2010
+  ghc-options:       -Wall
 
 executable metar
   hs-source-dirs:      app

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,15 @@
+# 0.1.0.2
+
+* Add version bounds to dependencies.
+* Turn on GHC warnings
+* The parser uses hackage/parsers library, so a user can choose the parser implementation e.g. attoparsec, parsec.
+* A METAR optionally ends in $ or = instead of necessarily.
+* Added a field to `Weather` for ending in $ (meaning the station requires maintenance).
+* Added classy lenses to the data types.
+* Updated the new noaa.gov METAR publication website for fetching.
+* Moved parseWeather over to the `Fetcher` module so the parser does not ever import attoparsec.
+* Make `Station` a newtype.
+
 # Jun 28 2016
 
-First release.
+* First release.

--- a/src/Data/Aviation/WX/Fetcher.hs
+++ b/src/Data/Aviation/WX/Fetcher.hs
@@ -1,21 +1,30 @@
-module Data.Aviation.WX.Fetcher where
+{-# LANGUAGE OverloadedStrings #-}
 
-import Data.Char
-import Data.List (filter)
-import Data.Text (pack)
-import Network.HTTP
+module Data.Aviation.WX.Fetcher(
+  parseWeather
+, fetchMetar
+) where
 
-import Data.Aviation.WX
+import Data.Attoparsec.Text(parseOnly)
+import Data.Aviation.WX(Weather, weatherParser)
+import Data.Char(toUpper, isAlpha)
+import Data.List(filter)
+import Data.Text(Text, pack)
+import Network.HTTP(simpleHTTP, getRequest, getResponseBody)
 
 type ICAOStationDesignator = String
+
+-- | Parse the given METAR text.
+parseWeather :: Text -> Either String Weather
+parseWeather = parseOnly weatherParser
 
 fetchMetar :: ICAOStationDesignator -> IO (Either String Weather)
 fetchMetar icao = do
     let icao' = map toUpper . filter isAlpha $ icao
     metarString <- simpleHTTP (getRequest $ url icao') >>= getResponseBody
-    let wx = pack $ "METAR " ++ relLine metarString ++ "="
-    putStrLn $ "Parsing " ++ show wx
-    return $ parseWeather wx
+    let wx' = pack $ "METAR " ++ relLine metarString
+    putStrLn $ "Parsing " ++ show wx'
+    return $ parseWeather wx'
     where
-        url designator = "http://weather.noaa.gov/pub/data/observations/metar/stations/" ++ designator ++ ".TXT"
+        url designator = "http://tgftp.nws.noaa.gov/data/observations/metar/stations/" ++ designator ++ ".TXT"
         relLine s = Prelude.lines s !! 1


### PR DESCRIPTION
- Add version bounds to dependencies.
- Turn on GHC warnings
- The parser uses hackage/parsers library, so a user can choose the parser implementation e.g. attoparsec, parsec.
- A METAR optionally ends in $ or = instead of necessarily.
- Added a field to `Weather` for ending in $ (meaning the station requires maintenance).
- Added classy lenses to the data types.
- Updated the new noaa.gov METAR publication website for fetching.
- Moved parseWeather over to the `Fetcher` module so the parser does not ever import attoparsec.
- Make `Station` a newtype.
